### PR TITLE
Add release infrastructure

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,4 @@
+Unreleased
+
+0.2.3 2013-05-12
+	CHANGELOG starts

--- a/README.md
+++ b/README.md
@@ -139,3 +139,13 @@ Run the tests:
 ``` bash
 ruby test/sinatra/router_test.rb
 ```
+
+## Release
+
+1. Update the version in `json_schema.gemspec` as appropriate for [semantic
+   versioning](http://semver.org) and add details to `CHANGELOG`.
+2. Run the `release` task:
+
+    ```
+    bundle exec rake release
+    ```

--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,12 @@
+require 'bundler'
 require 'rake/testtask'
+
+task :default => :test
+
+Bundler::GemHelper.install_tasks
 
 Rake::TestTask.new do |t|
   t.libs << "test"
   t.test_files = FileList['test/**/*_test.rb']
   t.verbose = true
 end
-
-task :default => :test


### PR DESCRIPTION
Adds a few niceties for releases: a Rake task, a CHANGELOG, and instructions in the README.