### PR TITLE
Use ruby/setup-ruby in CI, add Ruby 3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: [ '2.4', '2.5', '2.6', '2.7' ]
+        ruby: [ '2.4', '2.5', '2.6', '2.7', '3.0' ]
 
     name: Ruby ${{ matrix.ruby }}
 
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
 


### PR DESCRIPTION
Switches CI over to using https://github.com/ruby/setup-ruby

As https://github.com/actions/setup-ruby has been deprecated: https://github.com/actions/setup-ruby/commit/e932e7af67fc4a8fc77bd86b744acd4e42fe3543