### PR TITLE
Relax maximum Sinatra version constraint to allow version 4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: [ '2.7', '3.0', '3.1', '3.2' ]
+        ruby: [ '3.0', '3.1', '3.2', '3.3' ]
 
     name: Ruby ${{ matrix.ruby }}
 

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,7 @@
 
 source 'https://rubygems.org/'
 gemspec
+
+gem 'minitest'
+gem 'rack-test'
+gem 'rake'

--- a/sinatra-router.gemspec
+++ b/sinatra-router.gemspec
@@ -17,9 +17,5 @@ Gem::Specification.new do |gem|
 
   gem.files = ['lib/sinatra/router.rb']
 
-  gem.add_dependency 'sinatra', '>= 1.4', '< 4.0'
-
-  gem.add_development_dependency 'minitest'
-  gem.add_development_dependency 'rack-test'
-  gem.add_development_dependency 'rake'
+  gem.add_dependency 'sinatra', '>= 1.4'
 end


### PR DESCRIPTION
The test suite seems to pass with Sinatra 4, so here relax the maximum
version constraint on Sinatra to allow it.

Add Ruby 3.3 to test matrix. Drop support for Ruby 2.7.

Move development dependencies to `Gemfile` because RuboCop seems to want
this now.

Fixes #16.